### PR TITLE
Add static pegasus seed drop in Moosh Nuun

### DIFF
--- a/asm/layouts.yaml
+++ b/asm/layouts.yaml
@@ -254,3 +254,6 @@ ages:
   # put a "return bush" for long hook across from syrup's shop.
   23/7ea0/: db 27,c8
   23/7ead/: db 22
+
+  # change bush type in moosh nuun (for static peg seed drop)
+  26/4501/: db c8

--- a/asm/misc.yaml
+++ b/asm/misc.yaml
@@ -245,3 +245,22 @@ ages:
   15/75bf/: db setglobalflag,a2 # bit 7 = unset flag
 
   3f/4607/: ld hl,seedCapacityTable
+
+  # static pegasus seed item drop in moosh nuun
+  12/nuunMooshConditionalPegDropObjects: |
+      db f2
+      db 9a,d4,68,48     # vanilla worker object
+      db f0,04           # conditional moosh
+      db fa              # obj_itemDrop
+      db 00,07,58        # 07 = peg seeds, 58 = coordinates
+      db fe
+  #12/5a9b/: |
+  #    db f2             # vanilla
+  #    db 9a,b4,28,50    # vanilla
+  #    db 9a,d4,68,48    # 4 bytes replaced with:
+  12/5aa0/: |
+      db f3; dw nuunMooshConditionalPegDropObjects
+      db f2
+  #   db d0,03,3f,50     # vanilla
+  #   db f3; dw 436b     # vanilla
+  #   ff                 # vanilla


### PR DESCRIPTION
### Reason for PR:

We talked about this softlock potential of the nuun highlands cave check on discord before and the topic of using a static pegasus drop from one of the bushes came up. I tried my hand at implementing that functionality while keeping as much vanilla code as possible.

### Change Description:

Inserted a obj_Pointer into group0Map27ObjectData, with disassembly macros for easier readability:

```
obj_DoubleValue $9ad4 $68 $48  # vanilla data that got replaced for pointer
obj_Conditional $04            # conditional for moosh nuun
obj_ItemDrop $00 $07 $58       # Drop Pegasus Seed ($07) at coordinates 5,8
obj_EndPointer
```

### Considerations:

1. I included the surrounding vanilla code to make it easier to grasp the changes. Probably better to remove those when merging.

2. I don't know if misc.yaml is the right place for those changes. I put them there because I don't know where else they would really fit.